### PR TITLE
Only validate/test `./rules`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	semgrep --validate --config=$$PWD/rules $$PWD
-	semgrep --test --strict $$PWD
+	semgrep --validate --config=./rules ./rules
+	semgrep --test --strict ./rules
 output:
-	semgrep --test --strict --save-test-output-tar $$PWD
+	semgrep --test --strict --save-test-output-tar ./rules


### PR DESCRIPTION
Existing `Makefile` will run rules validation and tests on current working directory which will include `semgrep` submodule and all its submodules, which I believe is undesirable.

I also replaced `$$PWD` with `.` as its more idiomatic IMO.