### PR TITLE
Ignore semgrep test output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+semgrep_runs_output.json
+semgrep_runs_output.tar.gz


### PR DESCRIPTION
I presume in general its not desirable to commit these test output files to the repo.